### PR TITLE
Add initial Slot creation for new users

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'api.apps.ApiConfig'

--- a/api/apps.py
+++ b/api/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class ApiConfig(AppConfig):
     name = 'api'
+
+    def ready(self):
+        import api.signals

--- a/api/signals.py
+++ b/api/signals.py
@@ -1,0 +1,16 @@
+from django.contrib.auth import get_user_model
+from django.dispatch import receiver
+from django.db.models.signals import post_save
+
+User = get_user_model()
+
+from api.models import Slot
+
+
+@receiver(post_save, sender=User)
+def create_slots(sender, instance, created, **kwargs):
+    if created:
+        slot_total = 4
+        slots = [Slot(name=f'Slot {i+1}', user=instance)
+                    for i in range(slot_total)]
+        Slot.objects.bulk_create(slots)


### PR DESCRIPTION
For **NEWLY** created Users this should attach 4 initial Slots to that User using Django Signals.

>**NOTE**: If you have existing Users in the database, this code will not ensure your existing Users get 4 slots. So either you need to add them in manually in the Admin Dashboard OR wipe your database and re-migrate and re-create those Users again.